### PR TITLE
fix: ensure docker compose filetype uses yaml parser

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -27,7 +27,7 @@ return {
           },
         },
       }
-      vim.treesitter.language.register("yaml", "compose.yml")
+      vim.treesitter.language.register("yaml", "yaml.docker-compose")
     end,
   },
 


### PR DESCRIPTION
## Summary
- register the yaml parser for the yaml.docker-compose filetype within the Treesitter configuration

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f778935fc4832581aaf6b3c24513e8