### PR TITLE
feat: merge LSP server overrides with defaults

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -33,12 +33,18 @@ return {
     capabilities.workspace.didChangeWatchedFiles.dynamicRegistration = true
     ---@diagnostic enable: missing-fields
 
-    vim.lsp.config("*", {
+    local default_config = {
       capabilities = capabilities,
       root_markers = { ".git" },
-    })
+    }
+
+    vim.lsp.config("*", default_config)
 
     for _, server in pairs(opts.servers) do
+      local ok, conf = pcall(require, "lsp." .. server)
+      local server_config = vim.tbl_deep_extend("force", {}, default_config, ok and conf or {})
+
+      vim.lsp.config(server, server_config)
       vim.lsp.enable(server)
     end
 


### PR DESCRIPTION
## Summary
- create a shared default LSP configuration and apply it to all servers
- merge server-specific overrides from `lsp/<server>.lua` modules before enabling each server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f778932fa8832597c4b0e3dbf16c0a