### PR TITLE
fix: add plenary dependency to blink git source

### DIFF
--- a/lua/plugins/blink.lua
+++ b/lua/plugins/blink.lua
@@ -4,8 +4,7 @@ return {
   dependencies = {
     "rafamadriz/friendly-snippets",
     "echasnovski/mini.icons",
-    "Kaiser-Yang/blink-cmp-git",
-    dependencies = { "nvim-lua/plenary.nvim" },
+    { "Kaiser-Yang/blink-cmp-git", dependencies = { "nvim-lua/plenary.nvim" } },
   },
 
   version = "*",


### PR DESCRIPTION
## Summary
- convert the blink git source plugin entry into a table specification
- add plenary.nvim as an explicit dependency for blink-cmp-git

## Testing
- nvim --headless "+Lazy! sync" +qa *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f77893637c8325b4dc7a154ded1225