### PR TITLE
chore: deduplicate option assignments

### DIFF
--- a/lua/config/opt.lua
+++ b/lua/config/opt.lua
@@ -3,14 +3,15 @@ vim.opt.laststatus = 3
 vim.opt.splitkeep = "screen"
 vim.g.loaded_netrw = 1
 vim.g.loaded_netrwPlugin = 1
-vim.opt.autoindent = true
 vim.opt.autoread = true
 vim.opt.cursorcolumn = false
 vim.opt.cursorline = true
 vim.opt.expandtab = true
+vim.opt.autoindent = true
+vim.opt.smartindent = true
+vim.opt.cindent = true
 vim.opt.hlsearch = true
 vim.opt.ignorecase = true
-vim.opt.laststatus = 2
 vim.opt.listchars = { tab = "» ", trail = "·", nbsp = "␣" }
 vim.opt.list = true
 vim.opt.mouse = "a"
@@ -20,7 +21,6 @@ vim.opt.shiftwidth = 2
 vim.opt.shortmess:append "I"
 vim.opt.showcmd = true
 vim.opt.smartcase = true
-vim.opt.smartindent = true
 vim.opt.swapfile = false
 vim.opt.tabstop = 2
 vim.opt.wildcharm = 26
@@ -31,7 +31,3 @@ vim.opt.wildmode = "longest:full,full"
 vim.opt.wildoptions = "pum"
 vim.opt.wrap = true
 vim.o.scl = "yes"
-
-vim.opt.autoindent = true
-vim.opt.smartindent = true
-vim.opt.cindent = true


### PR DESCRIPTION
## Summary
- keep the global statusline configuration and remove the redundant per-window setting
- consolidate indent-related options so each is configured once

## Testing
- nvim --headless -u init.lua +"set laststatus?" +"set autoindent?" +q *(fails: `nvim` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f77896bbe083259d80eef04f0ac734